### PR TITLE
Add extension point in message serialize routine.

### DIFF
--- a/source/xmpp-messages.adb
+++ b/source/xmpp-messages.adb
@@ -219,6 +219,8 @@ package body XMPP.Messages is
          Writer.End_Element (Qualified_Name => Thread_Element);
       end if;
 
+      XMPP_Message'Class (Self).Custom_Content (Writer);
+
       Writer.End_Element (Qualified_Name => Message_Element);
    end Serialize;
 

--- a/source/xmpp-messages.ads
+++ b/source/xmpp-messages.ads
@@ -167,6 +167,11 @@ package XMPP.Messages is
                           Parameter : League.Strings.Universal_String;
                           Value     : League.Strings.Universal_String);
 
+   not overriding procedure Custom_Content
+    (Self   : XMPP_Message;
+     Writer : in out XML.SAX.Pretty_Writers.XML_Pretty_Writer'Class) is null;
+   --  Override this to populate message with custom content
+
 private
 
    type XMPP_Message is new XMPP.Objects.XMPP_Object with


### PR DESCRIPTION
We can use this to allow custom message content for derived messages.
It could be used for example to implement xep-0071 and add HTML
representation of the message.