### PR TITLE
With plain login method

### DIFF
--- a/source/xmpp-plain_auth.adb
+++ b/source/xmpp-plain_auth.adb
@@ -1,0 +1,89 @@
+--  xmpp-plain_auth.adb ---
+
+--  Copyright 2020 cnngimenez
+--
+--  Author: cnngimenez
+
+--  This program is free software: you can redistribute it and/or modify
+--  it under the terms of the GNU General Public License as published by
+--  the Free Software Foundation, either version 3 of the License, or
+--  (at your option) any later version.
+
+--  This program is distributed in the hope that it will be useful,
+--  but WITHOUT ANY WARRANTY; without even the implied warranty of
+--  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+--  GNU General Public License for more details.
+
+--  You should have received a copy of the GNU General Public License
+--  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+-------------------------------------------------------------------------
+
+with Ada.Characters.Conversions;
+with Ada.Streams;
+use Ada.Streams;
+
+with XMPP.Base64;
+
+package body XMPP.PLAIN_Auth is
+    
+    --  Create the stream needed by the Base64.Encode procedure.
+    function Generate_Stream (Username, Password : Wide_Wide_String)
+                             return Stream_Element_Array is
+        
+        Length : constant Stream_Element_Offset := 
+          Username'Length + Password'Length + 2;
+        Stream_Index : Stream_Element_Offset;
+        
+        Stream_Array : Stream_Element_Array (0 .. Length);
+        
+    begin
+        --  Zero character
+        Stream_Array (0) := 0;
+        
+        --  Username
+        Stream_Index := 1;
+        for I in Username'Range loop
+            Stream_Array (Stream_Index) := 
+              Stream_Element (Wide_Wide_Character'Pos (Username (I)));
+            Stream_Index := Stream_Index + 1;
+        end loop;
+        
+        --  Zero character
+        Stream_Array (Stream_Index) := 0;
+        Stream_Index := Stream_Index + 1;
+        
+        --  Password
+        for I in Password'Range loop
+            Stream_Array (Stream_Index) := 
+              Stream_Element (Wide_Wide_Character'Pos (Password (I)));
+            Stream_Index := Stream_Index + 1;
+        end loop;
+        
+        return Stream_Array;
+    end Generate_Stream;
+
+    function Plain_Password (Username, Password : Wide_Wide_String)
+                            return Wide_Wide_String is
+        
+        --  The result will have 33% more size at the most according to the 
+        --  Base64 standard.
+        Length : constant Natural := 
+          Natural 
+          (Float'Ceiling 
+             (1.33 * 
+                Float (Username'Length + Password'Length + 4)));
+          
+        Data : String (1 .. Length);
+        Last : Natural;
+        
+        use Ada.Characters.Conversions;
+    begin
+        XMPP.Base64.Encode (Generate_Stream (Username, Password),
+                            Data, Last);
+        
+        return To_Wide_Wide_String (Data);                
+    end Plain_Password;
+    
+    
+end XMPP.PLAIN_Auth;

--- a/source/xmpp-plain_auth.adb
+++ b/source/xmpp-plain_auth.adb
@@ -25,8 +25,8 @@ use Ada.Streams;
 
 with XMPP.Utils;
 with XMPP.Base64;
-with XMPP.Logger;
-use XMPP.Logger;
+--  with XMPP.Logger;
+--  use XMPP.Logger;
 
 package body XMPP.PLAIN_Auth is
 
@@ -38,7 +38,7 @@ package body XMPP.PLAIN_Auth is
                              return Stream_Element_Array is
 
         Length : constant Stream_Element_Offset :=
-          Username'Length + Password'Length + 2;
+          Username'Length + Password'Length + 1;
         Stream_Index : Stream_Element_Offset;
 
         Stream_Array : Stream_Element_Array (0 .. Length);
@@ -89,11 +89,11 @@ package body XMPP.PLAIN_Auth is
 
         use Ada.Characters.Conversions;
     begin
-        Log (Just_Username);
-        Log (Password);
+        --  Log (Just_Username);
+        --  Log (Password);
         XMPP.Base64.Encode (Generate_Stream (Just_Username, Password),
                             Data, Last);
-        Log (Last'Wide_Wide_Image);
+        --  Log (Last'Wide_Wide_Image);
         return To_Wide_Wide_String (Data (1 .. Last));
     end Plain_Password;
 

--- a/source/xmpp-plain_auth.ads
+++ b/source/xmpp-plain_auth.ads
@@ -19,14 +19,13 @@
 
 -------------------------------------------------------------------------
 
-
 --
 --  PLAIN authentication implemented for XMPP.
 --
 package XMPP.PLAIN_Auth is
-    
+
     --  Return the username and password as a PLAIN Base64 string
     function Plain_Password (Username, Password : Wide_Wide_String)
                             return Wide_Wide_String;
-    
+
 end XMPP.PLAIN_Auth;

--- a/source/xmpp-plain_auth.ads
+++ b/source/xmpp-plain_auth.ads
@@ -1,0 +1,32 @@
+--  xmpp-plain_auth.ads ---
+
+--  Copyright 2020 cnngimenez
+--
+--  Author: cnngimenez
+
+--  This program is free software: you can redistribute it and/or modify
+--  it under the terms of the GNU General Public License as published by
+--  the Free Software Foundation, either version 3 of the License, or
+--  (at your option) any later version.
+
+--  This program is distributed in the hope that it will be useful,
+--  but WITHOUT ANY WARRANTY; without even the implied warranty of
+--  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+--  GNU General Public License for more details.
+
+--  You should have received a copy of the GNU General Public License
+--  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+-------------------------------------------------------------------------
+
+
+--
+--  PLAIN authentication implemented for XMPP.
+--
+package XMPP.PLAIN_Auth is
+    
+    --  Return the username and password as a PLAIN Base64 string
+    function Plain_Password (Username, Password : Wide_Wide_String)
+                            return Wide_Wide_String;
+    
+end XMPP.PLAIN_Auth;

--- a/source/xmpp-sessions.adb
+++ b/source/xmpp-sessions.adb
@@ -60,6 +60,7 @@ with XMPP.Streams;
 with XMPP.Stream_Features;
 with XMPP.Utils;
 with XMPP.Versions;
+with XMPP.PLAIN_Auth;
 
 package body XMPP.Sessions is
 
@@ -240,7 +241,11 @@ package body XMPP.Sessions is
                Log ("Starting sasl auth");
                Self.Send_Wide_Wide_String
                  ("<auth xmlns='urn:ietf:params:xml:ns:xmpp-sasl' "
-                    & "mechanism='DIGEST-MD5'/>");
+                    & "mechanism='PLAIN'>"
+                    & XMPP.PLAIN_Auth.Plain_Password
+                    (Self.JID.To_Wide_Wide_String,
+                     Self.Password.To_Wide_Wide_String)
+                    & "</auth>");
             end if;
 
             Self.Stack.Delete_Last;

--- a/source/xmpp-utils.adb
+++ b/source/xmpp-utils.adb
@@ -83,6 +83,24 @@ package body XMPP.Utils is
       return Tmp & Image (Int_Id);
    end Gen_Id;
 
+   function Remove_Host (JID : Wide_Wide_String) return Wide_Wide_String is
+        Arroba_Founded : Boolean := False;
+        I : Natural := JID'First;
+    begin
+        while I <= JID'Length and not Arroba_Founded loop
+            Arroba_Founded := JID (I) = '@';
+            I := I + 1;
+        end loop;
+
+        if I <= JID'Length then
+            I := I - 2;
+        else
+            I := I - 1;
+        end if;
+
+        return JID (JID'First .. I);
+    end Remove_Host;
+
    -------------------------------
    --  To_Stream_Element_Array  --
    -------------------------------

--- a/source/xmpp-utils.ads
+++ b/source/xmpp-utils.ads
@@ -51,4 +51,6 @@ package XMPP.Utils is
                       := League.Strings.Empty_Universal_String)
      return League.Strings.Universal_String;
 
+   --  Remove the '@host' part from a JID if it exist.
+   function Remove_Host (JID : Wide_Wide_String) return Wide_Wide_String;
 end XMPP.Utils;


### PR DESCRIPTION
* Changed DIGEST-MD5 method to PLAIN which is the last alternative on Prosody. 
* Added a `XMPP.Utils.Remove_Host` procedure to remove the Host part from a JID.